### PR TITLE
Connects the Github endpoint to Post creation

### DIFF
--- a/app/controllers/webhooks/github_controller.rb
+++ b/app/controllers/webhooks/github_controller.rb
@@ -3,7 +3,13 @@ module Webhooks
     respond_to :json
 
     def push_event
-      render_status :ok
+      update = QueuePostUpdates.new(params).call
+
+      if update.success?
+        render_status :ok
+      else
+        render_status :error
+      end
     end
   end
 end

--- a/app/services/create_post.rb
+++ b/app/services/create_post.rb
@@ -1,0 +1,11 @@
+class CreatePost
+  def initialize(file)
+    @file = file
+  end
+
+  def call
+    post = Post.create(slug: @file.slug, publication_date: Time.zone.today)
+
+    ServiceCall.new(post, post.errors)
+  end
+end

--- a/app/services/queue_post_updates.rb
+++ b/app/services/queue_post_updates.rb
@@ -1,0 +1,20 @@
+class QueuePostUpdates
+  def initialize(params)
+    @params = params
+    @result = ServiceCall.new
+  end
+
+  def call
+    parse_data.files.added.each { |file| CreatePost.new(file).call }
+
+    @result
+  end
+
+  private
+
+  def parse_data
+    Github::Webhooks::PushEvent.parse(@params)
+  rescue Github::Webhooks::PushEvent::Parser::ParseError => error
+    @result.errors << error
+  end
+end

--- a/app/services/service_call.rb
+++ b/app/services/service_call.rb
@@ -1,0 +1,12 @@
+class ServiceCall
+  attr_accessor :data, :errors
+
+  def initialize(data = nil, errors = nil)
+    @data = data
+    @errors = *errors || []
+  end
+
+  def success?
+    errors.empty?
+  end
+end

--- a/lib/github/webhooks/push_event.rb
+++ b/lib/github/webhooks/push_event.rb
@@ -15,6 +15,18 @@ module Github
         end
       end
 
+      class File
+        attr_reader :name
+
+        def initialize(name)
+          @name = name
+        end
+
+        def slug
+          name.split('.').first
+        end
+      end
+
       class Files
         attr_reader :added, :removed, :modified
 
@@ -56,6 +68,10 @@ module Github
         def files
           documents = %i(added removed modified).each_with_object({}) do |operation, document|
             document[operation] = @payload[:commits].flat_map { |commit| commit[operation] }.compact
+          end
+
+          documents.each do |operation, files|
+            documents[operation] = files.map { |file| File.new(file) }
           end
 
           Files.new(documents[:added], documents[:removed], documents[:modified])

--- a/spec/controllers/webhooks/github_controller_spec.rb
+++ b/spec/controllers/webhooks/github_controller_spec.rb
@@ -6,7 +6,7 @@ describe Webhooks::GithubController do
     before { post :push_event, params }
 
     context 'with valid parameters' do
-      let(:params) { { ref: 'refs/heads/master' } }
+      let(:params) { { ref: 'refs/heads/master', commits: [] } }
 
       it { expect(response).to have_http_status(:success) }
     end

--- a/spec/github/webhooks/push_event_spec.rb
+++ b/spec/github/webhooks/push_event_spec.rb
@@ -1,7 +1,15 @@
 require 'rails_helper'
 
 describe Github::Webhooks::PushEvent do
-  let(:payload) { { ref: 'refs/heads/master', commits: [{ author: 'Yoda', added: ['foo.md'] }, { author: 'Obi-Wan', added: ['bar.md'] }] } }
+  let(:payload) do
+    {
+      ref: 'refs/heads/master',
+      commits: [
+        { author: 'Yoda', added: %w(foo.md bar.md), modified: [] },
+        { author: 'Obi-Wan', added: %w(baz.md), modified: %w(foo.md) }
+      ]
+    }
+  end
 
   describe '.parse' do
     subject(:result) { described_class.parse(payload) }
@@ -9,7 +17,10 @@ describe Github::Webhooks::PushEvent do
     context 'with valid payload' do
       it { expect(result.branch).to eq('master') }
       it { expect(result.authors).to eq(%w(Yoda Obi-Wan)) }
-      it { expect(result.files.added).to eq(%w(foo.md bar.md)) }
+      it { expect(result.files.added.map(&:name)).to eq(%w(foo.md bar.md baz.md)) }
+      it { expect(result.files.added.map(&:slug)).to eq(%w(foo bar baz)) }
+      it { expect(result.files.modified.map(&:name)).to eq(%w(foo.md)) }
+      it { expect(result.files.modified.map(&:slug)).to eq(%w(foo)) }
     end
 
     context 'without a valid ref' do

--- a/spec/services/create_post_spec.rb
+++ b/spec/services/create_post_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe CreatePost, type: :service do
+  let(:file) { double('file', slug: 'on-the-road') }
+
+  describe '#call' do
+    subject(:service_call) { described_class.new(file).call }
+
+    context 'with valid parameters' do
+      it { expect(service_call).to be_success }
+    end
+
+    context 'with invalid parameters' do
+      before { allow(file).to receive(:slug) { '' } }
+
+      it { expect(service_call).not_to be_success }
+    end
+  end
+end


### PR DESCRIPTION
This change allows Github push events to trigger creation of `Post`s.

This will be enhanced to fire up a background worker that grabs the content of the post.
