### PR TITLE
Add PostsController#index action for listing posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,9 @@
 class PostsController < ApplicationController
+  def index
+    @posts = Post.all.map { |post| PostDecorator.new(post) }
+  end
+
   def show
-    @post = PostDecorator.new(Post.find_by(slug: params[:slug]))
+    @post = PostDecorator.new(Post.find_by!(slug: params[:id]))
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,9 @@
+module ApplicationHelper
+  def slugged_post_path(post)
+    post_path(id: post.slug)
+  end
+
+  def slugged_post_url(post)
+    post_url(id: post.slug)
+  end
+end

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,0 +1,4 @@
+ol
+- @posts.each do |post|
+  li
+    = link_to post.title, slugged_post_path(post)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
     end
   end
 
-  get "posts/:slug", to: 'posts#show'
+  resources :posts, only: [:index, :show]
 end

--- a/spec/controllers/posts_controller.rb
+++ b/spec/controllers/posts_controller.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe PostsController do
+  describe "GET #index" do
+    let(:posts) { FactoryGirl.build_list(:post, 5) }
+
+    before do
+      allow(Post).to receive(:all) { posts }
+    end
+
+    before { get :index }
+
+    it { expect(response).to have_http_status(:success) }
+    it { expect(response).to render_template(:index) }
+  end
+
+  describe "GET #show" do
+    let(:post) { FactoryGirl.build_stubbed(:post) }
+
+    before do
+      allow(Post).to receive(:find_by).with(slug: post.slug.to_s) { post }
+    end
+
+    before { get :show, id: post.slug }
+
+    it { expect(response).to have_http_status(:success) }
+    it { expect(response).to render_template(:show) }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper do
+  describe "#slugged_post_path" do
+    let(:post) { FactoryGirl.build_stubbed(:post) }
+
+    it { expect(slugged_post_path(post)).to eq("/posts/#{post.slug}") }
+  end
+
+  describe "#slugged_post_url" do
+    let(:post) { FactoryGirl.build_stubbed(:post) }
+
+    it { expect(slugged_post_url(post)).to eq("#{@request.protocol}#{@request.host}/posts/#{post.slug}") }
+  end
+end

--- a/spec/routing/posts_routing_spec.rb
+++ b/spec/routing/posts_routing_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 
 RSpec.describe PostsController do
-  it { expect(get: "posts/on-the-road").to route_to("posts#show", slug: "on-the-road") }
+  it { expect(get: "posts").to route_to("posts#index") }
+  it { expect(get: "posts/on-the-road").to route_to("posts#show", id: "on-the-road") }
 end


### PR DESCRIPTION
This change adds a `PostsController#index` action, and tests for `PostsController`. It also resourcifies `PostsController#show`, and adds some helpers for slugged links.
