### PR TITLE
Add authors and publication date to posts listing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Style/StringLiterals:
   Enabled: true
   EnforcedStyle: double_quotes
 
+Style/Alias:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: true
 

--- a/app/decorators/base_decorator.rb
+++ b/app/decorators/base_decorator.rb
@@ -1,1 +1,3 @@
-class BaseDecorator < SimpleDelegator; end
+class BaseDecorator < SimpleDelegator
+  alias_method :model, :__getobj__
+end

--- a/app/decorators/post_decorator.rb
+++ b/app/decorators/post_decorator.rb
@@ -4,4 +4,12 @@ class PostDecorator < BaseDecorator
     markdown = Redcarpet::Markdown.new(renderer, {})
     markdown.render(body)
   end
+
+  def authors
+    model.authors.pluck(:name).to_sentence
+  end
+
+  def publication_date
+    model.publication_date.strftime("%-d %B")
+  end
 end

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -1,4 +1,6 @@
 ol
 - @posts.each do |post|
   li
-    = link_to post.title, slugged_post_path(post)
+    = link_to slugged_post_path(post) do
+      h1 #{post.title}
+    p #{post.publication_date} &mdash; by #{post.authors}

--- a/spec/decorators/base_decorator.rb
+++ b/spec/decorators/base_decorator.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe BaseDecorator do
+  let(:model) { instance_double("Model") }
+
+  subject(:decorator) { described_class.new(model) }
+
+  describe "#model" do
+    it { expect(decorator.model).to eq(model) }
+  end
+end

--- a/spec/decorators/post_decorator_spec.rb
+++ b/spec/decorators/post_decorator_spec.rb
@@ -1,11 +1,33 @@
 require "rails_helper"
 
 RSpec.describe PostDecorator do
-  let!(:post) { FactoryGirl.create(:post) }
+  let!(:post) { FactoryGirl.build_stubbed(:post) }
 
   subject(:decorator) { described_class.new(post) }
 
   describe "#content" do
     it { expect(decorator.content).to eq("<h1>On The Road</h1>\n") }
+  end
+
+  describe "#publication_date" do
+    it { expect(decorator.publication_date).to eq("5 September") }
+  end
+
+  describe "#authors" do
+    before do
+      allow(decorator.model.authors).to receive(:pluck).with(:name) { authors }
+    end
+
+    context "with a single author" do
+      let(:authors) { ["Ted Johansson"] }
+
+      it { expect(decorator.authors).to eq("Ted Johansson") }
+    end
+
+    context "with several authors" do
+      let(:authors) { ["Jaryl Sim", "Ted Johansson", "Matthew Yeow"] }
+
+      it { expect(decorator.authors).to eq("Jaryl Sim, Ted Johansson, and Matthew Yeow") }
+    end
   end
 end

--- a/spec/github/file_spec.rb
+++ b/spec/github/file_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe Github::File do
   end
 
   describe "#uri" do
-    it { expect(file.uri.to_s).to eq("#{ENV["POSTS_URL"]}/master/foo.md") }
+    it { expect(file.uri.to_s).to eq("#{ENV['POSTS_URL']}/master/foo.md") }
   end
 end


### PR DESCRIPTION
This change adds some view logic for authors and publication date of a post, and adds them to the posts listing.

It also adds a `#model` method to base decorator, to give an entry point to the original model. This allows overriding methods for view purposes, without completely obscuring the original model.
