### PR TITLE
Extract proper titles for posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,5 +2,6 @@ class Post < ActiveRecord::Base
   has_many :authorships, inverse_of: :post
   has_many :authors, through: :authorships, inverse_of: :posts
 
-  validates :slug, presence: true
+  validates :title, presence: true
+  validates :slug, presence: true, uniqueness: true
 end

--- a/app/services/create_post.rb
+++ b/app/services/create_post.rb
@@ -6,7 +6,7 @@ class CreatePost
   end
 
   def call
-    post = Post.create(slug: @file.slug, body: remote_file_content, publication_date: Time.zone.today)
+    post = Post.create(title: extracted_title, slug: @file.slug, body: remote_file_content, publication_date: Time.zone.today)
 
     ServiceCall.new(post, post.errors)
   end
@@ -14,6 +14,10 @@ class CreatePost
   private
 
   def remote_file_content
-    Net::HTTP.get(@file.uri)
+    _remote_file_content ||= Net::HTTP.get(@file.uri)
+  end
+
+  def extracted_title
+    remote_file_content.match(/^\s*#\s?(.+)/)&.captures&.first || ""
   end
 end

--- a/db/migrate/20150723114920_create_posts.rb
+++ b/db/migrate/20150723114920_create_posts.rb
@@ -1,11 +1,14 @@
 class CreatePosts < ActiveRecord::Migration
   def change
     create_table :posts do |t|
-      t.string :title
-      t.date :publication_date
-      t.text :body
+      t.string :title, null: false
+      t.string :slug, null: false
+      t.date :publication_date, null: false
+      t.text :body, null: false
 
       t.timestamps null: false
     end
+
+    add_index :posts, :slug, unique: true
   end
 end

--- a/db/migrate/20150723130528_add_slug_to_posts.rb
+++ b/db/migrate/20150723130528_add_slug_to_posts.rb
@@ -1,5 +1,0 @@
-class AddSlugToPosts < ActiveRecord::Migration
-  def change
-    add_column :posts, :slug, :string, null: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150723130528) do
+ActiveRecord::Schema.define(version: 20150723115106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,13 +33,15 @@ ActiveRecord::Schema.define(version: 20150723130528) do
   add_index "authorships", ["post_id"], name: "index_authorships_on_post_id", using: :btree
 
   create_table "posts", force: :cascade do |t|
-    t.string   "title"
-    t.date     "publication_date"
-    t.text     "body"
+    t.string   "title",            null: false
+    t.string   "slug",             null: false
+    t.date     "publication_date", null: false
+    t.text     "body",             null: false
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
-    t.string   "slug",             null: false
   end
+
+  add_index "posts", ["slug"], name: "index_posts_on_slug", unique: true, using: :btree
 
   add_foreign_key "authorships", "authors"
   add_foreign_key "authorships", "posts"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,8 +1,12 @@
 require "rails_helper"
 
 RSpec.describe Post do
+  subject { FactoryGirl.build(:post) }
+
   it { is_expected.to have_many(:authorships).inverse_of(:post) }
   it { is_expected.to have_many(:authors).through(:authorships).inverse_of(:posts) }
 
+  it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:slug) }
+  it { is_expected.to validate_uniqueness_of(:slug) }
 end

--- a/spec/services/create_post_spec.rb
+++ b/spec/services/create_post_spec.rb
@@ -1,23 +1,37 @@
 require "rails_helper"
 
 RSpec.describe CreatePost, type: :service do
-  let(:file) { double("file", slug: "on-the-road", uri: "") }
+  let(:file) { instance_double("Github::File", slug: "on-the-road", uri: "") }
 
   describe "#call" do
     subject(:service_call) { described_class.new(file).call }
 
-    before { allow(Net::HTTP).to receive(:get) { "Hello world!" } }
+    let(:remote_file_content) { "# Disciplined Rails" }
+
+    before do
+      allow(Net::HTTP).to receive(:get) { remote_file_content }
+    end
 
     context "with valid parameters" do
       context "when fetching remote data is successful" do
         it { expect(service_call).to be_success }
+
+        it { expect(service_call.data.title).to eq("Disciplined Rails") }
       end
     end
 
     context "with invalid parameters" do
-      before { allow(file).to receive(:slug) { "" } }
+      context "without a slug" do
+        before { allow(file).to receive(:slug) { "" } }
 
-      it { expect(service_call).not_to be_success }
+        it { expect(service_call).not_to be_success }
+      end
+
+      context "without an extractable title" do
+        let(:remote_file_content) { "Disciplined Rails" }
+
+        it { expect(service_call).not_to be_success }
+      end
     end
   end
 end


### PR DESCRIPTION
This change extracts a proper title from the remote file, and stores it in the database. It also adds some constraints and database indices.

Currently, the post must start with (optionally preceded by any amount of whitespace) a markdown top level heading (`#`), which will be used as the title for the post.
