### PR TITLE
Extract meaningful author details from the GitHub payload

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - tmp/**/*
     - vendor/**/*
     - .gems/**/*
+  TargetRubyVersion: 2.3
 
 Rails:
   Enabled: true
@@ -60,6 +61,9 @@ Style/StringLiterals:
 Style/Alias:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Metrics/CyclomaticComplexity:
   Enabled: true
 
@@ -72,3 +76,6 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 30
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -3,4 +3,6 @@ class Author < ActiveRecord::Base
   has_many :posts, through: :authorships, inverse_of: :authors
 
   validates :name, presence: true
+  validates :email, presence: true, uniqueness: true
+  validates :username, presence: true, uniqueness: true
 end

--- a/app/services/create_post.rb
+++ b/app/services/create_post.rb
@@ -1,12 +1,13 @@
 require "net/http"
 
 class CreatePost
-  def initialize(file)
+  def initialize(file, authors = [])
     @file = file
+    @authors = authors
   end
 
   def call
-    post = Post.create(title: extracted_title, slug: @file.slug, body: remote_file_content, publication_date: Time.zone.today)
+    post = Post.create(title: extracted_title, slug: @file.slug, body: remote_file_content, publication_date: Time.zone.today, authors: authors)
 
     ServiceCall.new(post, post.errors)
   end
@@ -19,5 +20,11 @@ class CreatePost
 
   def extracted_title
     remote_file_content.match(/^\s*#\s?(.+)/)&.captures&.first || ""
+  end
+
+  def authors
+    _authors ||= @authors.map do |author|
+      Author.find_or_initialize_by(email: author.email).initialize_with(name: author.name, username: author.username)
+    end
   end
 end

--- a/db/migrate/20150723115014_create_authors.rb
+++ b/db/migrate/20150723115014_create_authors.rb
@@ -1,9 +1,14 @@
 class CreateAuthors < ActiveRecord::Migration
   def change
     create_table :authors do |t|
-      t.string :name
+      t.string :name, null: false
+      t.string :email, null: false
+      t.string :username, null: false
 
       t.timestamps null: false
     end
+
+    add_index :authors, :email, unique: true
+    add_index :authors, :username, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,9 @@ ActiveRecord::Schema.define(version: 20150723115106) do
   enable_extension "plpgsql"
 
   create_table "authors", force: :cascade do |t|
-    t.string   "name"
+    t.string   "name",       null: false
+    t.string   "email",      null: false
+    t.string   "username",   null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,8 @@
 puts "Seeding Authors ..."
 
-Author.create!(name: "Jaryl Sim")
-Author.create!(name: "Ted Johansson")
-Author.create!(name: "Matthew Yeow")
+Author.create!(name: "Jaryl Sim", email: "jaryl@adaptoid.io", username: "j4ryl")
+Author.create!(name: "Ted Johansson", email: "hello@adaptoid.io", username: "dr3nmi")
+Author.create!(name: "Matthew Yeow", email: "matt@adaptoid.io", username: "m4tt")
 
 puts "Seeding Posts ..."
 

--- a/lib/github/author.rb
+++ b/lib/github/author.rb
@@ -1,0 +1,11 @@
+module Github
+  class Author
+    attr_reader :name, :email, :username
+
+    def initialize(name, email, username)
+      @name = name || ""
+      @email = email || ""
+      @username = username || ""
+    end
+  end
+end

--- a/lib/github/webhooks/push_event.rb
+++ b/lib/github/webhooks/push_event.rb
@@ -35,7 +35,9 @@ module Github
         end
 
         def authors
-          @payload[:commits].map { |commit| commit[:author] }
+          @payload[:commits].map do |commit|
+            Github::Author.new(commit[:author][:name], commit[:author][:email], commit[:author][:username])
+          end
         end
 
         def files

--- a/spec/factories/authors.rb
+++ b/spec/factories/authors.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
   factory :author do
     name "Jack Kerouac"
+    sequence(:email) { |n| "jack.#{n}@adaptoid.io" }
+    sequence(:username) { |n| "jack#{n}" }
 
     trait :invalid do
       name ""

--- a/spec/github/author_spec.rb
+++ b/spec/github/author_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Github::Author do
+  subject(:author) { described_class.new("Ted Johansson", "hello@adaptoid.io", "adaptoid-io") }
+
+  describe "#name" do
+    it { expect(author.name).to eq("Ted Johansson") }
+  end
+
+  describe "#email" do
+    it { expect(author.email).to eq("hello@adaptoid.io") }
+  end
+
+  describe "#username" do
+    it { expect(author.username).to eq("adaptoid-io") }
+  end
+end

--- a/spec/github/webhooks/push_event_spec.rb
+++ b/spec/github/webhooks/push_event_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Github::Webhooks::PushEvent do
     {
       ref: "refs/heads/master",
       commits: [
-        { author: "Yoda", added: %w(foo.md bar.md), modified: [] },
-        { author: "Obi-Wan", added: %w(baz.md), modified: %w(foo.md) }
+        { author: { name: "Yoda", email: "yoda@adaptoid.io", username: "y0da" }, added: %w(foo.md bar.md), modified: [] },
+        { author: { name: "Obi-Wan", email: "obi-wan@adaptoid.io", username: "n3o" }, added: %w(baz.md), modified: %w(foo.md) }
       ]
     }
   end
@@ -16,9 +16,14 @@ RSpec.describe Github::Webhooks::PushEvent do
 
     context "with valid payload" do
       it { expect(result.branch).to eq("master") }
-      it { expect(result.authors).to eq(%w(Yoda Obi-Wan)) }
+
+      it { expect(result.authors.map(&:name)).to eq(%w(Yoda Obi-Wan)) }
+      it { expect(result.authors.map(&:email)).to eq(%w(yoda@adaptoid.io obi-wan@adaptoid.io)) }
+      it { expect(result.authors.map(&:username)).to eq(%w(y0da n3o)) }
+
       it { expect(result.files.added.map(&:name)).to eq(%w(foo.md bar.md baz.md)) }
       it { expect(result.files.added.map(&:slug)).to eq(%w(foo bar baz)) }
+
       it { expect(result.files.modified.map(&:name)).to eq(%w(foo.md)) }
       it { expect(result.files.modified.map(&:slug)).to eq(%w(foo)) }
     end

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,8 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Author do
+  subject { FactoryGirl.build(:author) }
+
   it { is_expected.to have_many(:authorships).inverse_of(:author) }
   it { is_expected.to have_many(:posts).through(:authorships).inverse_of(:authors) }
 
   it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_presence_of(:username) }
+  it { is_expected.to validate_uniqueness_of(:email) }
+  it { is_expected.to validate_uniqueness_of(:username) }
 end


### PR DESCRIPTION
The following are now extracted into a Github::Author object:
- Name.
- E-mail.
- Username.
