### PR TITLE
Fix memoization in CreatePost service

### DIFF
--- a/app/services/create_post.rb
+++ b/app/services/create_post.rb
@@ -15,15 +15,15 @@ class CreatePost
   private
 
   def remote_file_content
-    _remote_file_content ||= Net::HTTP.get(@file.uri)
+    @remote_file_content ||= Net::HTTP.get(@file.uri)
   end
 
   def extracted_title
-    remote_file_content.match(/^\s*#\s?(.+)/)&.captures&.first || ""
+    remote_file_content.match(/^\s*#\s?(.+)/).to_a.second.to_s
   end
 
   def authors
-    _authors ||= @authors.map do |author|
+    @authors ||= @authors.map do |author|
       Author.find_or_initialize_by(email: author.email).initialize_with(name: author.name, username: author.username)
     end
   end


### PR DESCRIPTION
The `CreatePost` service implemented memoization incorrectly in a couple of places. This change fixes that.
